### PR TITLE
feat: プロジェクト初期化とNode構造体の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Binaries
+chaos-kvs
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary
+*.test
+
+# Output of go coverage
+*.out
+coverage.html
+
+# Go workspace
+go.work
+go.work.sum
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+.PHONY: build test fmt lint quality clean run
+
+# Binary name
+BINARY=chaos-kvs
+
+# Build the application
+build:
+	go build -o $(BINARY) .
+
+# Run tests
+test:
+	go test -v ./...
+
+# Format code
+fmt:
+	go fmt ./...
+
+# Run linter (if golangci-lint is installed)
+lint:
+	golangci-lint run
+
+# Run all quality checks (required before commit)
+quality: fmt test lint
+
+# Clean build artifacts
+clean:
+	rm -f $(BINARY)
+	go clean
+
+# Run the application
+run: build
+	./$(BINARY)

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module chaos-kvs
+
+go 1.25.2

--- a/main.go
+++ b/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	fmt.Println("ChaosKVS - High-Concurrency In-Memory KVS Simulator")
+	fmt.Println("====================================================")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// デモ: 単一ノードの起動
+	node := NewNode("node-1")
+	if err := node.Start(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start node: %v\n", err)
+		os.Exit(1)
+	}
+
+	// デモ: データの読み書き
+	_ = node.Set("hello", []byte("world"))
+	if value, ok := node.Get("hello"); ok {
+		fmt.Printf("[INFO] Get 'hello' = '%s'\n", string(value))
+	}
+
+	fmt.Printf("[INFO] Node %s is running with %d keys\n", node.ID, node.Size())
+
+	// シグナル待機
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	fmt.Println("[INFO] Press Ctrl+C to stop...")
+	<-sigCh
+
+	fmt.Println("\n[INFO] Shutting down...")
+	_ = node.Stop()
+	fmt.Println("[INFO] Goodbye!")
+}

--- a/node.go
+++ b/node.go
@@ -1,0 +1,149 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// NodeStatus はノードの状態を表す
+type NodeStatus int
+
+const (
+	NodeStatusStopped NodeStatus = iota
+	NodeStatusRunning
+	NodeStatusSuspended
+)
+
+func (s NodeStatus) String() string {
+	switch s {
+	case NodeStatusStopped:
+		return "stopped"
+	case NodeStatusRunning:
+		return "running"
+	case NodeStatusSuspended:
+		return "suspended"
+	default:
+		return "unknown"
+	}
+}
+
+// Node はインメモリKVSの単一ノードを表す
+type Node struct {
+	ID     string
+	status NodeStatus
+
+	mu   sync.RWMutex
+	data map[string][]byte
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+// NewNode は新しいノードを作成する
+func NewNode(id string) *Node {
+	return &Node{
+		ID:     id,
+		status: NodeStatusStopped,
+		data:   make(map[string][]byte),
+	}
+}
+
+// Start はノードを起動する
+func (n *Node) Start(ctx context.Context) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.status == NodeStatusRunning {
+		return fmt.Errorf("node %s is already running", n.ID)
+	}
+
+	n.ctx, n.cancel = context.WithCancel(ctx)
+	n.status = NodeStatusRunning
+
+	fmt.Printf("[INFO] Node %s started\n", n.ID)
+	return nil
+}
+
+// Stop はノードを停止する
+func (n *Node) Stop() error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.status == NodeStatusStopped {
+		return fmt.Errorf("node %s is already stopped", n.ID)
+	}
+
+	if n.cancel != nil {
+		n.cancel()
+	}
+	n.status = NodeStatusStopped
+
+	fmt.Printf("[INFO] Node %s stopped\n", n.ID)
+	return nil
+}
+
+// Status はノードの現在のステータスを返す
+func (n *Node) Status() NodeStatus {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return n.status
+}
+
+// Get はキーに対応する値を取得する
+func (n *Node) Get(key string) ([]byte, bool) {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	if n.status != NodeStatusRunning {
+		return nil, false
+	}
+
+	value, exists := n.data[key]
+	return value, exists
+}
+
+// Set はキーに値を設定する
+func (n *Node) Set(key string, value []byte) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.status != NodeStatusRunning {
+		return fmt.Errorf("node %s is not running", n.ID)
+	}
+
+	n.data[key] = value
+	return nil
+}
+
+// Delete はキーを削除する
+func (n *Node) Delete(key string) error {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+
+	if n.status != NodeStatusRunning {
+		return fmt.Errorf("node %s is not running", n.ID)
+	}
+
+	delete(n.data, key)
+	return nil
+}
+
+// Keys は全てのキーを返す
+func (n *Node) Keys() []string {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
+	keys := make([]string, 0, len(n.data))
+	for k := range n.data {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// Size はデータストアのサイズを返す
+func (n *Node) Size() int {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	return len(n.data)
+}

--- a/node_test.go
+++ b/node_test.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+func TestNewNode(t *testing.T) {
+	node := NewNode("test-node-1")
+
+	if node.ID != "test-node-1" {
+		t.Errorf("expected ID 'test-node-1', got '%s'", node.ID)
+	}
+
+	if node.Status() != NodeStatusStopped {
+		t.Errorf("expected status Stopped, got %v", node.Status())
+	}
+}
+
+func TestNodeStartStop(t *testing.T) {
+	node := NewNode("test-node-1")
+	ctx := context.Background()
+
+	// Start
+	if err := node.Start(ctx); err != nil {
+		t.Errorf("failed to start node: %v", err)
+	}
+
+	if node.Status() != NodeStatusRunning {
+		t.Errorf("expected status Running, got %v", node.Status())
+	}
+
+	// Double start should fail
+	if err := node.Start(ctx); err == nil {
+		t.Error("expected error when starting already running node")
+	}
+
+	// Stop
+	if err := node.Stop(); err != nil {
+		t.Errorf("failed to stop node: %v", err)
+	}
+
+	if node.Status() != NodeStatusStopped {
+		t.Errorf("expected status Stopped, got %v", node.Status())
+	}
+
+	// Double stop should fail
+	if err := node.Stop(); err == nil {
+		t.Error("expected error when stopping already stopped node")
+	}
+}
+
+func TestNodeGetSet(t *testing.T) {
+	node := NewNode("test-node-1")
+	ctx := context.Background()
+
+	// Set before start should fail
+	if err := node.Set("key1", []byte("value1")); err == nil {
+		t.Error("expected error when setting on stopped node")
+	}
+
+	// Get before start should return false
+	if _, ok := node.Get("key1"); ok {
+		t.Error("expected Get to return false on stopped node")
+	}
+
+	// Start node
+	_ = node.Start(ctx)
+
+	// Set
+	if err := node.Set("key1", []byte("value1")); err != nil {
+		t.Errorf("failed to set: %v", err)
+	}
+
+	// Get
+	value, ok := node.Get("key1")
+	if !ok {
+		t.Error("expected Get to return true")
+	}
+	if string(value) != "value1" {
+		t.Errorf("expected 'value1', got '%s'", string(value))
+	}
+
+	// Get non-existent key
+	if _, ok := node.Get("nonexistent"); ok {
+		t.Error("expected Get to return false for non-existent key")
+	}
+}
+
+func TestNodeDelete(t *testing.T) {
+	node := NewNode("test-node-1")
+	ctx := context.Background()
+	_ = node.Start(ctx)
+
+	_ = node.Set("key1", []byte("value1"))
+
+	if err := node.Delete("key1"); err != nil {
+		t.Errorf("failed to delete: %v", err)
+	}
+
+	if _, ok := node.Get("key1"); ok {
+		t.Error("expected key to be deleted")
+	}
+}
+
+func TestNodeKeys(t *testing.T) {
+	node := NewNode("test-node-1")
+	ctx := context.Background()
+	_ = node.Start(ctx)
+
+	_ = node.Set("key1", []byte("value1"))
+	_ = node.Set("key2", []byte("value2"))
+	_ = node.Set("key3", []byte("value3"))
+
+	keys := node.Keys()
+	if len(keys) != 3 {
+		t.Errorf("expected 3 keys, got %d", len(keys))
+	}
+}
+
+func TestNodeSize(t *testing.T) {
+	node := NewNode("test-node-1")
+	ctx := context.Background()
+	_ = node.Start(ctx)
+
+	if node.Size() != 0 {
+		t.Errorf("expected size 0, got %d", node.Size())
+	}
+
+	_ = node.Set("key1", []byte("value1"))
+	_ = node.Set("key2", []byte("value2"))
+
+	if node.Size() != 2 {
+		t.Errorf("expected size 2, got %d", node.Size())
+	}
+}
+
+func TestNodeConcurrentAccess(t *testing.T) {
+	node := NewNode("test-node-1")
+	ctx := context.Background()
+	_ = node.Start(ctx)
+
+	var wg sync.WaitGroup
+	numGoroutines := 100
+
+	// Concurrent writes
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := string(rune('a' + i%26))
+			_ = node.Set(key, []byte("value"))
+		}(i)
+	}
+
+	// Concurrent reads
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			key := string(rune('a' + i%26))
+			node.Get(key)
+		}(i)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## 概要
Phase 1 の最初の2つのタスクを実装しました。

- プロジェクトの初期化 (Issue #1)
- 基本的な Node 構造体の実装 (Issue #2)

## 変更内容

### プロジェクト初期化
- `go mod init chaos-kvs` でGoモジュールを初期化
- `.gitignore` を追加（バイナリ、IDE設定、OS固有ファイルを除外）
- `Makefile` を追加（build, test, fmt, lint, quality コマンド）

### Node 構造体
- `NodeStatus` 型（Stopped, Running, Suspended）
- スレッドセーフな `Node` 構造体（`sync.RWMutex` 使用）
- Get/Set/Delete 操作
- ライフサイクル管理（Start/Stop）
- サイズ・キー一覧の取得

### テスト
- 基本操作のテスト
- 並行アクセステスト（100 Goroutine による同時読み書き）

## 動作確認
```bash
make quality  # 全テスト・lintパス
make run      # デモ実行
```

## Closes
- Closes #1
- Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)