### PR TITLE
feat: Clusterマネージャーとログ機能の実装

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// Cluster は複数のノードを管理する
+type Cluster struct {
+	mu    sync.RWMutex
+	nodes map[string]*Node
+	ctx   context.Context
+}
+
+// NewCluster は新しいクラスタを作成する
+func NewCluster() *Cluster {
+	return &Cluster{
+		nodes: make(map[string]*Node),
+	}
+}
+
+// AddNode はクラスタにノードを追加する
+func (c *Cluster) AddNode(node *Node) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if _, exists := c.nodes[node.ID]; exists {
+		return fmt.Errorf("node %s already exists in cluster", node.ID)
+	}
+
+	c.nodes[node.ID] = node
+	LogInfo("", "Node %s added to cluster", node.ID)
+	return nil
+}
+
+// RemoveNode はクラスタからノードを削除する
+func (c *Cluster) RemoveNode(nodeID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	node, exists := c.nodes[nodeID]
+	if !exists {
+		return fmt.Errorf("node %s not found in cluster", nodeID)
+	}
+
+	if node.Status() == NodeStatusRunning {
+		_ = node.Stop()
+	}
+
+	delete(c.nodes, nodeID)
+	LogInfo("", "Node %s removed from cluster", nodeID)
+	return nil
+}
+
+// GetNode はノードIDでノードを取得する
+func (c *Cluster) GetNode(nodeID string) (*Node, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	node, exists := c.nodes[nodeID]
+	return node, exists
+}
+
+// Nodes は全てのノードを返す
+func (c *Cluster) Nodes() []*Node {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	nodes := make([]*Node, 0, len(c.nodes))
+	for _, node := range c.nodes {
+		nodes = append(nodes, node)
+	}
+	return nodes
+}
+
+// StartAll は全てのノードを起動する
+func (c *Cluster) StartAll(ctx context.Context) error {
+	c.mu.Lock()
+	c.ctx = ctx
+	nodes := make([]*Node, 0, len(c.nodes))
+	for _, node := range c.nodes {
+		nodes = append(nodes, node)
+	}
+	c.mu.Unlock()
+
+	LogInfo("", "Starting all nodes in cluster (count: %d)", len(nodes))
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(nodes))
+
+	for _, node := range nodes {
+		wg.Add(1)
+		go func(n *Node) {
+			defer wg.Done()
+			if err := n.Start(ctx); err != nil {
+				errCh <- err
+			}
+		}(node)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		LogError("", "Failed to start %d nodes", len(errs))
+		return fmt.Errorf("failed to start %d nodes", len(errs))
+	}
+
+	LogInfo("", "All nodes started successfully")
+	return nil
+}
+
+// StopAll は全てのノードを停止する
+func (c *Cluster) StopAll() error {
+	c.mu.RLock()
+	nodes := make([]*Node, 0, len(c.nodes))
+	for _, node := range c.nodes {
+		nodes = append(nodes, node)
+	}
+	c.mu.RUnlock()
+
+	LogInfo("", "Stopping all nodes in cluster (count: %d)", len(nodes))
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, len(nodes))
+
+	for _, node := range nodes {
+		wg.Add(1)
+		go func(n *Node) {
+			defer wg.Done()
+			if err := n.Stop(); err != nil {
+				errCh <- err
+			}
+		}(node)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	var errs []error
+	for err := range errCh {
+		errs = append(errs, err)
+	}
+
+	if len(errs) > 0 {
+		LogWarn("", "Failed to stop %d nodes (may already be stopped)", len(errs))
+	}
+
+	LogInfo("", "All nodes stopped")
+	return nil
+}
+
+// Size はクラスタ内のノード数を返す
+func (c *Cluster) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.nodes)
+}
+
+// RunningCount は実行中のノード数を返す
+func (c *Cluster) RunningCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	count := 0
+	for _, node := range c.nodes {
+		if node.Status() == NodeStatusRunning {
+			count++
+		}
+	}
+	return count
+}
+
+// StoppedCount は停止中のノード数を返す
+func (c *Cluster) StoppedCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	count := 0
+	for _, node := range c.nodes {
+		if node.Status() == NodeStatusStopped {
+			count++
+		}
+	}
+	return count
+}
+
+// CreateNodes は指定された数のノードを作成してクラスタに追加する
+func (c *Cluster) CreateNodes(count int, prefix string) error {
+	LogInfo("", "Creating %d nodes with prefix '%s'", count, prefix)
+
+	for i := range count {
+		nodeID := fmt.Sprintf("%s-%d", prefix, i+1)
+		node := NewNode(nodeID)
+		if err := c.AddNode(node); err != nil {
+			return err
+		}
+	}
+
+	LogInfo("", "Created %d nodes successfully", count)
+	return nil
+}

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1,0 +1,146 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestNewCluster(t *testing.T) {
+	cluster := NewCluster()
+
+	if cluster.Size() != 0 {
+		t.Errorf("expected size 0, got %d", cluster.Size())
+	}
+}
+
+func TestClusterAddRemoveNode(t *testing.T) {
+	cluster := NewCluster()
+	node := NewNode("test-node-1")
+
+	// Add
+	if err := cluster.AddNode(node); err != nil {
+		t.Errorf("failed to add node: %v", err)
+	}
+
+	if cluster.Size() != 1 {
+		t.Errorf("expected size 1, got %d", cluster.Size())
+	}
+
+	// Add duplicate should fail
+	if err := cluster.AddNode(node); err == nil {
+		t.Error("expected error when adding duplicate node")
+	}
+
+	// Get
+	retrieved, ok := cluster.GetNode("test-node-1")
+	if !ok {
+		t.Error("expected to find node")
+	}
+	if retrieved.ID != node.ID {
+		t.Errorf("expected ID %s, got %s", node.ID, retrieved.ID)
+	}
+
+	// Remove
+	if err := cluster.RemoveNode("test-node-1"); err != nil {
+		t.Errorf("failed to remove node: %v", err)
+	}
+
+	if cluster.Size() != 0 {
+		t.Errorf("expected size 0, got %d", cluster.Size())
+	}
+
+	// Remove non-existent should fail
+	if err := cluster.RemoveNode("test-node-1"); err == nil {
+		t.Error("expected error when removing non-existent node")
+	}
+}
+
+func TestClusterStartStopAll(t *testing.T) {
+	cluster := NewCluster()
+	ctx := context.Background()
+
+	_ = cluster.CreateNodes(5, "node")
+
+	// Start all
+	if err := cluster.StartAll(ctx); err != nil {
+		t.Errorf("failed to start all: %v", err)
+	}
+
+	if cluster.RunningCount() != 5 {
+		t.Errorf("expected 5 running, got %d", cluster.RunningCount())
+	}
+
+	if cluster.StoppedCount() != 0 {
+		t.Errorf("expected 0 stopped, got %d", cluster.StoppedCount())
+	}
+
+	// Stop all
+	if err := cluster.StopAll(); err != nil {
+		t.Errorf("failed to stop all: %v", err)
+	}
+
+	if cluster.RunningCount() != 0 {
+		t.Errorf("expected 0 running, got %d", cluster.RunningCount())
+	}
+
+	if cluster.StoppedCount() != 5 {
+		t.Errorf("expected 5 stopped, got %d", cluster.StoppedCount())
+	}
+}
+
+func TestClusterNodes(t *testing.T) {
+	cluster := NewCluster()
+
+	_ = cluster.CreateNodes(3, "node")
+
+	nodes := cluster.Nodes()
+	if len(nodes) != 3 {
+		t.Errorf("expected 3 nodes, got %d", len(nodes))
+	}
+}
+
+func TestClusterCreateNodes(t *testing.T) {
+	cluster := NewCluster()
+
+	if err := cluster.CreateNodes(10, "test"); err != nil {
+		t.Errorf("failed to create nodes: %v", err)
+	}
+
+	if cluster.Size() != 10 {
+		t.Errorf("expected size 10, got %d", cluster.Size())
+	}
+
+	// Verify nodes exist
+	for i := 1; i <= 10; i++ {
+		nodeID := fmt.Sprintf("test-%d", i)
+		if _, ok := cluster.GetNode(nodeID); !ok {
+			t.Errorf("expected node %s to exist", nodeID)
+		}
+	}
+}
+
+func TestClusterConcurrentAccess(t *testing.T) {
+	cluster := NewCluster()
+	ctx := context.Background()
+
+	_ = cluster.CreateNodes(10, "node")
+	_ = cluster.StartAll(ctx)
+
+	var wg sync.WaitGroup
+
+	// Concurrent reads
+	for range 50 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = cluster.Nodes()
+			_ = cluster.Size()
+			_ = cluster.RunningCount()
+		}()
+	}
+
+	wg.Wait()
+	_ = cluster.StopAll()
+}

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+)
+
+// LogLevel はログレベルを表す
+type LogLevel int
+
+const (
+	LogLevelDebug LogLevel = iota
+	LogLevelInfo
+	LogLevelWarn
+	LogLevelError
+)
+
+func (l LogLevel) String() string {
+	switch l {
+	case LogLevelDebug:
+		return "DEBUG"
+	case LogLevelInfo:
+		return "INFO"
+	case LogLevelWarn:
+		return "WARN"
+	case LogLevelError:
+		return "ERROR"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+// Logger はスレッドセーフなロガー
+type Logger struct {
+	mu       sync.Mutex
+	out      io.Writer
+	minLevel LogLevel
+}
+
+// DefaultLogger はデフォルトのロガー
+var DefaultLogger = NewLogger(os.Stdout, LogLevelInfo)
+
+// NewLogger は新しいロガーを作成する
+func NewLogger(out io.Writer, minLevel LogLevel) *Logger {
+	return &Logger{
+		out:      out,
+		minLevel: minLevel,
+	}
+}
+
+// SetLevel はログレベルを設定する
+func (l *Logger) SetLevel(level LogLevel) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.minLevel = level
+}
+
+// log は指定されたレベルでログを出力する
+func (l *Logger) log(level LogLevel, nodeID string, format string, args ...any) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	if level < l.minLevel {
+		return
+	}
+
+	timestamp := time.Now().Format("2006-01-02 15:04:05.000")
+	msg := fmt.Sprintf(format, args...)
+
+	if nodeID != "" {
+		_, _ = fmt.Fprintf(l.out, "[%s] [%s] [%s] %s\n", timestamp, level, nodeID, msg)
+	} else {
+		_, _ = fmt.Fprintf(l.out, "[%s] [%s] %s\n", timestamp, level, msg)
+	}
+}
+
+// Debug はデバッグログを出力する
+func (l *Logger) Debug(nodeID string, format string, args ...any) {
+	l.log(LogLevelDebug, nodeID, format, args...)
+}
+
+// Info は情報ログを出力する
+func (l *Logger) Info(nodeID string, format string, args ...any) {
+	l.log(LogLevelInfo, nodeID, format, args...)
+}
+
+// Warn は警告ログを出力する
+func (l *Logger) Warn(nodeID string, format string, args ...any) {
+	l.log(LogLevelWarn, nodeID, format, args...)
+}
+
+// Error はエラーログを出力する
+func (l *Logger) Error(nodeID string, format string, args ...any) {
+	l.log(LogLevelError, nodeID, format, args...)
+}
+
+// グローバル関数（デフォルトロガーを使用）
+
+// LogDebug はデバッグログを出力する
+func LogDebug(nodeID string, format string, args ...any) {
+	DefaultLogger.Debug(nodeID, format, args...)
+}
+
+// LogInfo は情報ログを出力する
+func LogInfo(nodeID string, format string, args ...any) {
+	DefaultLogger.Info(nodeID, format, args...)
+}
+
+// LogWarn は警告ログを出力する
+func LogWarn(nodeID string, format string, args ...any) {
+	DefaultLogger.Warn(nodeID, format, args...)
+}
+
+// LogError はエラーログを出力する
+func LogError(nodeID string, format string, args ...any) {
+	DefaultLogger.Error(nodeID, format, args...)
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestLogLevel(t *testing.T) {
+	tests := []struct {
+		level    LogLevel
+		expected string
+	}{
+		{LogLevelDebug, "DEBUG"},
+		{LogLevelInfo, "INFO"},
+		{LogLevelWarn, "WARN"},
+		{LogLevelError, "ERROR"},
+		{LogLevel(99), "UNKNOWN"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.expected {
+			t.Errorf("LogLevel(%d).String() = %s, want %s", tt.level, got, tt.expected)
+		}
+	}
+}
+
+func TestLoggerOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(buf, LogLevelDebug)
+
+	logger.Debug("node-1", "debug message")
+	logger.Info("node-1", "info message")
+	logger.Warn("node-1", "warn message")
+	logger.Error("node-1", "error message")
+
+	output := buf.String()
+
+	if !strings.Contains(output, "[DEBUG]") {
+		t.Error("expected DEBUG log")
+	}
+	if !strings.Contains(output, "[INFO]") {
+		t.Error("expected INFO log")
+	}
+	if !strings.Contains(output, "[WARN]") {
+		t.Error("expected WARN log")
+	}
+	if !strings.Contains(output, "[ERROR]") {
+		t.Error("expected ERROR log")
+	}
+	if !strings.Contains(output, "[node-1]") {
+		t.Error("expected node ID in log")
+	}
+}
+
+func TestLoggerLevel(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(buf, LogLevelWarn)
+
+	logger.Debug("", "debug message")
+	logger.Info("", "info message")
+	logger.Warn("", "warn message")
+	logger.Error("", "error message")
+
+	output := buf.String()
+
+	if strings.Contains(output, "[DEBUG]") {
+		t.Error("DEBUG should be filtered")
+	}
+	if strings.Contains(output, "[INFO]") {
+		t.Error("INFO should be filtered")
+	}
+	if !strings.Contains(output, "[WARN]") {
+		t.Error("expected WARN log")
+	}
+	if !strings.Contains(output, "[ERROR]") {
+		t.Error("expected ERROR log")
+	}
+}
+
+func TestLoggerSetLevel(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(buf, LogLevelError)
+
+	logger.Info("", "should not appear")
+
+	if strings.Contains(buf.String(), "should not appear") {
+		t.Error("INFO should be filtered at ERROR level")
+	}
+
+	logger.SetLevel(LogLevelInfo)
+	logger.Info("", "should appear")
+
+	if !strings.Contains(buf.String(), "should appear") {
+		t.Error("INFO should appear after SetLevel")
+	}
+}
+
+func TestLoggerWithoutNodeID(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(buf, LogLevelInfo)
+
+	logger.Info("", "message without node")
+
+	output := buf.String()
+
+	// Should not have empty brackets
+	if strings.Contains(output, "[]") {
+		t.Error("should not have empty brackets for nodeID")
+	}
+	if !strings.Contains(output, "message without node") {
+		t.Error("expected message in output")
+	}
+}
+
+func TestLoggerFormatArgs(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewLogger(buf, LogLevelInfo)
+
+	logger.Info("node-1", "count: %d, name: %s", 42, "test")
+
+	output := buf.String()
+
+	if !strings.Contains(output, "count: 42, name: test") {
+		t.Errorf("expected formatted message, got: %s", output)
+	}
+}

--- a/node.go
+++ b/node.go
@@ -61,7 +61,7 @@ func (n *Node) Start(ctx context.Context) error {
 	n.ctx, n.cancel = context.WithCancel(ctx)
 	n.status = NodeStatusRunning
 
-	fmt.Printf("[INFO] Node %s started\n", n.ID)
+	LogInfo(n.ID, "Node started")
 	return nil
 }
 
@@ -79,7 +79,7 @@ func (n *Node) Stop() error {
 	}
 	n.status = NodeStatusStopped
 
-	fmt.Printf("[INFO] Node %s stopped\n", n.ID)
+	LogInfo(n.ID, "Node stopped")
 	return nil
 }
 


### PR DESCRIPTION
## 概要
Phase 1 の残り2つのタスクを実装しました。

- Clusterマネージャーの実装 (Issue #3)
- 基本的なログ出力の実装 (Issue #4)

## 変更内容

### Logger (`logger.go`)
- `LogLevel`: DEBUG, INFO, WARN, ERROR の4段階
- スレッドセーフな出力（`sync.Mutex`）
- タイムスタンプ + レベル + ノードID + メッセージ形式
- グローバル関数 `LogInfo()`, `LogError()` など

### Cluster (`cluster.go`)
- `AddNode` / `RemoveNode`: ノードの追加・削除
- `StartAll` / `StopAll`: 全ノードの並行起動・停止
- `CreateNodes`: 指定数のノードを一括作成
- `RunningCount` / `StoppedCount`: 状態別ノード数

### main.go の更新
- Clusterを使用したデモに変更
- 5ノードのクラスタを起動するサンプル

## テスト
- `cluster_test.go`: 6テストケース
- `logger_test.go`: 6テストケース
- 並行アクセステスト含む

## 動作確認
```bash
make quality  # 全テスト・lintパス
make run      # 5ノードクラスタのデモ
```

## Closes
- Closes #3
- Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)