### PR TITLE
fix: go.modのバージョンを1.23に修正

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module chaos-kvs
 
-go 1.25.2
+go 1.23


### PR DESCRIPTION
## 問題
go.modで `go 1.25.2` が指定されていたが、これは存在しないGoバージョン。
CIで以下のエラーが発生していた：

```
go: go.mod requires go >= 1.25.2 (running go 1.23.12; GOTOOLCHAIN=local)
```

## 修正
`go 1.23` に変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)