### PR TITLE
chore: Go 1.25に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Download dependencies
         run: go mod download
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -55,7 +55,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
 
       - name: Build
         run: go build -v ./...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module chaos-kvs
 
-go 1.23
+go 1.25


### PR DESCRIPTION
## 概要
Goを最新の安定版 1.25 に更新。

## 変更内容
- `go.mod`: go 1.23 → go 1.25
- `.github/workflows/ci.yml`: go-version 1.23 → 1.25

## Go 1.25の主な特徴
- 新しい実験的ガベージコレクター
- 新しい実験的 encoding/json/v2 パッケージ
- macOS 12 Monterey以降が必要

## 参考
- [Go 1.25 Release Notes](https://go.dev/doc/go1.25)
- [All releases](https://go.dev/dl/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)