### PR TITLE
refactor: 設定の外部化（ハードコード値の除去）

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -20,6 +20,18 @@ type Collector interface {
 // Ensure Metrics implements Collector
 var _ Collector = (*Metrics)(nil)
 
+// Config はメトリクスの設定
+type Config struct {
+	MaxLatencySamples int // P99計算用のサンプル数
+}
+
+// DefaultConfig はデフォルト設定を返す
+func DefaultConfig() Config {
+	return Config{
+		MaxLatencySamples: 1000,
+	}
+}
+
 // Metrics はリクエストのメトリクスを収集する
 type Metrics struct {
 	totalRequests   atomic.Uint64
@@ -37,12 +49,21 @@ type Metrics struct {
 
 // New は新しいメトリクスを作成する
 func New() *Metrics {
+	return NewWithConfig(DefaultConfig())
+}
+
+// NewWithConfig は設定を指定してメトリクスを作成する
+func NewWithConfig(config Config) *Metrics {
+	maxSamples := config.MaxLatencySamples
+	if maxSamples <= 0 {
+		maxSamples = 1000
+	}
 	now := time.Now()
 	return &Metrics{
 		startTime:         now,
 		lastResetTime:     now,
-		latencies:         make([]time.Duration, 0, 1000),
-		maxLatencySamples: 1000,
+		latencies:         make([]time.Duration, 0, maxSamples),
+		maxLatencySamples: maxSamples,
 	}
 }
 


### PR DESCRIPTION
## Summary
- マジックナンバーを設定構造体に外部化
- 後方互換性を維持しつつ柔軟な設定を可能に

## 変更内容
### worker パッケージ
```go
type PoolConfig struct {
    NumWorkers  int // ワーカー数（0でCPU数）
    QueueFactor int // キューサイズ = NumWorkers * QueueFactor (デフォルト100)
}

func NewPoolWithConfig(config PoolConfig) *Pool
```

### metrics パッケージ
```go
type Config struct {
    MaxLatencySamples int // P99計算用のサンプル数 (デフォルト1000)
}

func NewWithConfig(config Config) *Metrics
```

## 後方互換性
- `worker.NewPool()` と `metrics.New()` はデフォルト設定を使用
- 既存コードに影響なし

## Test plan
- [x] `make quality` 全テストパス、lint 0件

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)