### PR TITLE
docs: パッケージドキュメントの追加

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1,4 +1,3 @@
-// Package client provides a load generator for stress testing the cluster.
 package client
 
 import (

--- a/internal/client/doc.go
+++ b/internal/client/doc.go
@@ -1,0 +1,31 @@
+// Package client provides a load generator for stress testing the cluster.
+//
+// The Client generates read/write traffic against a cluster at a configurable
+// rate and ratio. It collects metrics about the generated load.
+//
+// # Basic Usage
+//
+//	c := cluster.New()
+//	c.CreateNodes(5, "node")
+//	c.StartAll(ctx)
+//
+//	config := client.DefaultConfig()
+//	config.WriteRatio = 0.3 // 30% writes, 70% reads
+//	cl := client.New(c, config)
+//
+//	// Run for a duration
+//	snap := cl.RunFor(ctx, 10*time.Second)
+//	fmt.Printf("Total: %d, RPS: %.2f\n", snap.TotalRequests, snap.RPS)
+//
+//	// Or run a fixed number of requests
+//	snap := cl.RunRequests(ctx, 10000)
+//
+// # Configuration
+//
+// The Config struct allows tuning:
+//   - NumWorkers: parallel workers (0 = CPU count)
+//   - WriteRatio: fraction of write operations (0.0 to 1.0)
+//   - KeyRange: key space size
+//   - ValueSize: size of values in bytes
+//   - RequestsLimit: max requests (0 = unlimited)
+package client

--- a/internal/cluster/cluster.go
+++ b/internal/cluster/cluster.go
@@ -1,4 +1,3 @@
-// Package cluster provides multi-node cluster management.
 package cluster
 
 import (

--- a/internal/cluster/doc.go
+++ b/internal/cluster/doc.go
@@ -1,0 +1,30 @@
+// Package cluster provides multi-node cluster management.
+//
+// A Cluster manages multiple Node instances, providing operations for
+// batch starting/stopping and node discovery.
+//
+// # Basic Usage
+//
+//	c := cluster.New()
+//
+//	// Create and add nodes
+//	if err := c.CreateNodes(5, "node"); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Start all nodes
+//	if err := c.StartAll(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer c.StopAll()
+//
+//	// Access individual nodes
+//	if n, ok := c.GetNode("node-1"); ok {
+//	    n.Set("key", []byte("value"))
+//	}
+//
+// # Thread Safety
+//
+// All cluster operations are thread-safe and can be called concurrently.
+// Node starting and stopping is performed in parallel for efficiency.
+package cluster

--- a/internal/logger/doc.go
+++ b/internal/logger/doc.go
@@ -1,0 +1,30 @@
+// Package logger provides a simple, thread-safe logging facility.
+//
+// The logger supports four levels: Debug, Info, Warn, and Error.
+// Each log entry includes a timestamp, level, optional node ID, and message.
+//
+// # Basic Usage
+//
+// Using the default logger:
+//
+//	logger.Info("", "Application started")
+//	logger.Info("node-1", "Processing request")
+//	logger.Error("node-1", "Failed: %v", err)
+//
+// Creating a custom logger:
+//
+//	l := logger.New(os.Stderr, logger.LevelDebug)
+//	l.Debug("node-1", "Debug message")
+//
+// # Log Levels
+//
+// Messages below the configured level are filtered:
+//   - LevelDebug: all messages
+//   - LevelInfo: Info, Warn, Error
+//   - LevelWarn: Warn, Error
+//   - LevelError: Error only
+//
+// # Thread Safety
+//
+// All logging operations are protected by a mutex and safe for concurrent use.
+package logger

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,4 +1,3 @@
-// Package logger provides thread-safe logging functionality.
 package logger
 
 import (

--- a/internal/metrics/doc.go
+++ b/internal/metrics/doc.go
@@ -1,0 +1,35 @@
+// Package metrics provides request metrics collection and reporting.
+//
+// Metrics collects statistics about request latency, success/failure rates,
+// and throughput (RPS). It is thread-safe and optimized for high-concurrency
+// scenarios.
+//
+// # Basic Usage
+//
+//	m := metrics.New()
+//
+//	// Record requests
+//	start := time.Now()
+//	// ... do work ...
+//	m.RecordSuccess(time.Since(start))
+//
+//	// Get statistics
+//	fmt.Printf("Total: %d, RPS: %.2f, P99: %v\n",
+//	    m.TotalRequests(), m.RPS(), m.P99Latency())
+//
+//	// Get a snapshot
+//	snap := m.Snapshot()
+//
+// # Configuration
+//
+// Use NewWithConfig for custom settings:
+//
+//	config := metrics.Config{
+//	    MaxLatencySamples: 5000, // More samples for P99 accuracy
+//	}
+//	m := metrics.NewWithConfig(config)
+//
+// # Thread Safety
+//
+// All operations use atomic counters and are safe for concurrent access.
+package metrics

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,4 +1,3 @@
-// Package metrics provides request metrics collection and reporting.
 package metrics
 
 import (

--- a/internal/node/doc.go
+++ b/internal/node/doc.go
@@ -1,0 +1,33 @@
+// Package node provides an in-memory key-value store node implementation.
+//
+// Each Node represents a single KVS instance that can store and retrieve
+// key-value pairs. Nodes are thread-safe and support concurrent access.
+//
+// # Basic Usage
+//
+//	n := node.New("node-1")
+//	if err := n.Start(ctx); err != nil {
+//	    log.Fatal(err)
+//	}
+//	defer n.Stop()
+//
+//	// Store a value
+//	if err := n.Set("key", []byte("value")); err != nil {
+//	    log.Fatal(err)
+//	}
+//
+//	// Retrieve a value
+//	if value, ok := n.Get("key"); ok {
+//	    fmt.Println(string(value))
+//	}
+//
+// # Node Lifecycle
+//
+// A Node must be started before it can accept read/write operations.
+// The lifecycle is: Stopped -> Running -> Stopped.
+//
+// # Thread Safety
+//
+// All operations on a Node are protected by a RWMutex, allowing concurrent
+// reads while serializing writes.
+package node

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -1,4 +1,3 @@
-// Package node provides an in-memory key-value store node implementation.
 package node
 
 import (

--- a/internal/worker/doc.go
+++ b/internal/worker/doc.go
@@ -1,0 +1,33 @@
+// Package worker provides a goroutine pool for concurrent job execution.
+//
+// The Pool manages a fixed number of worker goroutines that process jobs
+// from a shared queue. It supports graceful shutdown and context cancellation.
+//
+// # Basic Usage
+//
+//	pool := worker.NewPool(4) // 4 workers
+//	pool.Start(ctx)
+//	defer pool.Stop()
+//
+//	// Submit jobs
+//	for i := 0; i < 100; i++ {
+//	    pool.Submit(func() {
+//	        // do work
+//	    })
+//	}
+//
+// # Configuration
+//
+// Use NewPoolWithConfig for custom settings:
+//
+//	config := worker.PoolConfig{
+//	    NumWorkers:  8,
+//	    QueueFactor: 200, // Queue size = 8 * 200 = 1600
+//	}
+//	pool := worker.NewPoolWithConfig(config)
+//
+// # Graceful Shutdown
+//
+// Stop() waits for all in-flight jobs to complete before returning.
+// The context passed to Start() can be used to cancel waiting jobs.
+package worker

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -1,4 +1,3 @@
-// Package worker provides a goroutine pool for concurrent job execution.
 package worker
 
 import (


### PR DESCRIPTION
## Summary
- 各パッケージにdoc.goファイルを追加し、GoDocドキュメントを充実
- 6つの全パッケージ（node, cluster, metrics, worker, client, logger）にドキュメントを追加
- 重複するパッケージコメントをメインソースファイルから削除

## Changes
- `internal/node/doc.go`: ノードパッケージのドキュメント追加
- `internal/cluster/doc.go`: クラスタパッケージのドキュメント追加
- `internal/metrics/doc.go`: メトリクスパッケージのドキュメント追加
- `internal/worker/doc.go`: ワーカープールパッケージのドキュメント追加
- `internal/client/doc.go`: クライアントパッケージのドキュメント追加
- `internal/logger/doc.go`: ロガーパッケージのドキュメント追加

## Test plan
- [x] `make quality` パス確認
- [x] `go doc` でドキュメント表示確認

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)