### PR TITLE
feat: ChaosMonkeyの実装

### DIFF
--- a/internal/chaos/chaos.go
+++ b/internal/chaos/chaos.go
@@ -1,0 +1,302 @@
+package chaos
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"chaos-kvs/internal/cluster"
+	"chaos-kvs/internal/logger"
+	"chaos-kvs/internal/node"
+)
+
+// AttackType は障害の種類を表す
+type AttackType int
+
+const (
+	AttackKill AttackType = iota
+	AttackSuspend
+	AttackDelay
+)
+
+func (a AttackType) String() string {
+	switch a {
+	case AttackKill:
+		return "kill"
+	case AttackSuspend:
+		return "suspend"
+	case AttackDelay:
+		return "delay"
+	default:
+		return "unknown"
+	}
+}
+
+// Config はChaosMonkeyの設定
+type Config struct {
+	Interval      time.Duration // 攻撃間隔
+	TargetCount   int           // 同時攻撃対象数
+	AttackTypes   []AttackType  // 有効な攻撃タイプ
+	DelayDuration time.Duration // Delay攻撃時の遅延時間
+	SuspendTime   time.Duration // Suspend攻撃の継続時間（0で手動Resume）
+}
+
+// DefaultConfig はデフォルト設定を返す
+func DefaultConfig() Config {
+	return Config{
+		Interval:      5 * time.Second,
+		TargetCount:   1,
+		AttackTypes:   []AttackType{AttackKill, AttackSuspend, AttackDelay},
+		DelayDuration: 100 * time.Millisecond,
+		SuspendTime:   3 * time.Second,
+	}
+}
+
+// Monkey はカオスエンジニアリングを実行する
+type Monkey struct {
+	config  Config
+	cluster *cluster.Cluster
+
+	running atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+
+	mu           sync.RWMutex
+	attackCount  uint64
+	lastAttack   time.Time
+	suspendedIDs map[string]time.Time
+}
+
+// New は新しいChaosMonkeyを作成する
+func New(c *cluster.Cluster, config Config) *Monkey {
+	return &Monkey{
+		config:       config,
+		cluster:      c,
+		suspendedIDs: make(map[string]time.Time),
+	}
+}
+
+// Start はカオス注入を開始する
+func (m *Monkey) Start(ctx context.Context) {
+	if m.running.Swap(true) {
+		return
+	}
+
+	m.ctx, m.cancel = context.WithCancel(ctx)
+
+	m.wg.Add(1)
+	go m.attackLoop()
+
+	if m.config.SuspendTime > 0 {
+		m.wg.Add(1)
+		go m.resumeLoop()
+	}
+
+	logger.Info("", "ChaosMonkey started (interval: %v, targets: %d)",
+		m.config.Interval, m.config.TargetCount)
+}
+
+// Stop はカオス注入を停止する
+func (m *Monkey) Stop() {
+	if !m.running.Swap(false) {
+		return
+	}
+
+	m.cancel()
+	m.wg.Wait()
+
+	// 残っているsuspendedノードをresumeする
+	m.resumeAll()
+
+	logger.Info("", "ChaosMonkey stopped (total attacks: %d)", m.attackCount)
+}
+
+// attackLoop は定期的に攻撃を実行する
+func (m *Monkey) attackLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.config.Interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.attack()
+		}
+	}
+}
+
+// resumeLoop はsuspendされたノードを自動的にresumeする
+func (m *Monkey) resumeLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(500 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkAndResume()
+		}
+	}
+}
+
+// attack は攻撃を実行する
+func (m *Monkey) attack() {
+	targets := m.selectTargets()
+	if len(targets) == 0 {
+		return
+	}
+
+	attackType := m.selectAttackType()
+
+	for _, n := range targets {
+		m.executeAttack(n, attackType)
+	}
+
+	m.mu.Lock()
+	m.attackCount++
+	m.lastAttack = time.Now()
+	m.mu.Unlock()
+}
+
+// selectTargets は攻撃対象のノードを選択する
+func (m *Monkey) selectTargets() []*node.Node {
+	nodes := m.cluster.Nodes()
+	if len(nodes) == 0 {
+		return nil
+	}
+
+	// 稼働中のノードのみを対象とする
+	running := make([]*node.Node, 0)
+	for _, n := range nodes {
+		if n.Status() == node.StatusRunning {
+			running = append(running, n)
+		}
+	}
+
+	if len(running) == 0 {
+		return nil
+	}
+
+	// ターゲット数を調整
+	count := m.config.TargetCount
+	if count > len(running) {
+		count = len(running)
+	}
+
+	// ランダムに選択
+	rand.Shuffle(len(running), func(i, j int) {
+		running[i], running[j] = running[j], running[i]
+	})
+
+	return running[:count]
+}
+
+// selectAttackType は攻撃タイプをランダムに選択する
+func (m *Monkey) selectAttackType() AttackType {
+	if len(m.config.AttackTypes) == 0 {
+		return AttackKill
+	}
+	return m.config.AttackTypes[rand.Intn(len(m.config.AttackTypes))]
+}
+
+// executeAttack は指定された攻撃を実行する
+func (m *Monkey) executeAttack(n *node.Node, attackType AttackType) {
+	switch attackType {
+	case AttackKill:
+		m.attackKill(n)
+	case AttackSuspend:
+		m.attackSuspend(n)
+	case AttackDelay:
+		m.attackDelay(n)
+	}
+}
+
+// attackKill はノードを強制停止する
+func (m *Monkey) attackKill(n *node.Node) {
+	if err := n.Stop(); err != nil {
+		logger.Warn("", "ChaosMonkey: failed to kill node %s: %v", n.ID(), err)
+		return
+	}
+	logger.Warn("", "ChaosMonkey: killed node %s", n.ID())
+}
+
+// attackSuspend はノードを一時停止する
+func (m *Monkey) attackSuspend(n *node.Node) {
+	if err := n.Suspend(); err != nil {
+		logger.Warn("", "ChaosMonkey: failed to suspend node %s: %v", n.ID(), err)
+		return
+	}
+
+	m.mu.Lock()
+	m.suspendedIDs[n.ID()] = time.Now()
+	m.mu.Unlock()
+
+	logger.Warn("", "ChaosMonkey: suspended node %s", n.ID())
+}
+
+// attackDelay はノードに遅延を注入する
+func (m *Monkey) attackDelay(n *node.Node) {
+	n.SetDelay(m.config.DelayDuration)
+	logger.Warn("", "ChaosMonkey: injected %v delay to node %s", m.config.DelayDuration, n.ID())
+}
+
+// checkAndResume はsuspend時間が経過したノードをresumeする
+func (m *Monkey) checkAndResume() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	now := time.Now()
+	for nodeID, suspendTime := range m.suspendedIDs {
+		if now.Sub(suspendTime) >= m.config.SuspendTime {
+			if n, exists := m.cluster.GetNode(nodeID); exists {
+				if err := n.Resume(); err == nil {
+					logger.Info("", "ChaosMonkey: auto-resumed node %s", nodeID)
+				}
+			}
+			delete(m.suspendedIDs, nodeID)
+		}
+	}
+}
+
+// resumeAll は全てのsuspendedノードをresumeする
+func (m *Monkey) resumeAll() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for nodeID := range m.suspendedIDs {
+		if n, exists := m.cluster.GetNode(nodeID); exists {
+			if err := n.Resume(); err == nil {
+				logger.Info("", "ChaosMonkey: resumed node %s on shutdown", nodeID)
+			}
+		}
+	}
+	m.suspendedIDs = make(map[string]time.Time)
+}
+
+// IsRunning は実行中かどうかを返す
+func (m *Monkey) IsRunning() bool {
+	return m.running.Load()
+}
+
+// AttackCount は攻撃回数を返す
+func (m *Monkey) AttackCount() uint64 {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.attackCount
+}
+
+// SetConfig は設定を更新する
+func (m *Monkey) SetConfig(config Config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.config = config
+}

--- a/internal/chaos/chaos_test.go
+++ b/internal/chaos/chaos_test.go
@@ -1,0 +1,259 @@
+package chaos
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"chaos-kvs/internal/cluster"
+	"chaos-kvs/internal/node"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	if config.Interval != 5*time.Second {
+		t.Errorf("expected interval 5s, got %v", config.Interval)
+	}
+	if config.TargetCount != 1 {
+		t.Errorf("expected target count 1, got %d", config.TargetCount)
+	}
+	if len(config.AttackTypes) != 3 {
+		t.Errorf("expected 3 attack types, got %d", len(config.AttackTypes))
+	}
+}
+
+func TestAttackTypeString(t *testing.T) {
+	tests := []struct {
+		attack   AttackType
+		expected string
+	}{
+		{AttackKill, "kill"},
+		{AttackSuspend, "suspend"},
+		{AttackDelay, "delay"},
+		{AttackType(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.attack.String(); got != tt.expected {
+			t.Errorf("AttackType(%d).String() = %s, want %s", tt.attack, got, tt.expected)
+		}
+	}
+}
+
+func TestNewMonkey(t *testing.T) {
+	c := cluster.New()
+	config := DefaultConfig()
+
+	monkey := New(c, config)
+
+	if monkey == nil {
+		t.Fatal("expected non-nil monkey")
+	}
+	if monkey.IsRunning() {
+		t.Error("expected monkey to not be running initially")
+	}
+}
+
+func TestMonkeyStartStop(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(3, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.Interval = 100 * time.Millisecond
+
+	monkey := New(c, config)
+
+	ctx := context.Background()
+	monkey.Start(ctx)
+
+	if !monkey.IsRunning() {
+		t.Error("expected monkey to be running after Start")
+	}
+
+	// 少し待ってから停止
+	time.Sleep(50 * time.Millisecond)
+
+	monkey.Stop()
+
+	if monkey.IsRunning() {
+		t.Error("expected monkey to not be running after Stop")
+	}
+}
+
+func TestMonkeyAttackKill(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(3, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.Interval = 50 * time.Millisecond
+	config.TargetCount = 1
+	config.AttackTypes = []AttackType{AttackKill}
+
+	monkey := New(c, config)
+
+	ctx := context.Background()
+	monkey.Start(ctx)
+
+	// 攻撃が発生するまで待つ
+	time.Sleep(100 * time.Millisecond)
+
+	monkey.Stop()
+
+	// 少なくとも1つのノードがStoppedになっているはず
+	stoppedCount := 0
+	for _, n := range c.Nodes() {
+		if n.Status() == node.StatusStopped {
+			stoppedCount++
+		}
+	}
+
+	if stoppedCount == 0 {
+		t.Error("expected at least one node to be killed")
+	}
+}
+
+func TestMonkeyAttackSuspend(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(3, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.Interval = 50 * time.Millisecond
+	config.TargetCount = 1
+	config.AttackTypes = []AttackType{AttackSuspend}
+	config.SuspendTime = 200 * time.Millisecond
+
+	monkey := New(c, config)
+
+	ctx := context.Background()
+	monkey.Start(ctx)
+
+	// 攻撃が発生するまで待つ
+	time.Sleep(100 * time.Millisecond)
+
+	// 少なくとも1つのノードがSuspendedになっているはず
+	suspendedCount := 0
+	for _, n := range c.Nodes() {
+		if n.Status() == node.StatusSuspended {
+			suspendedCount++
+		}
+	}
+
+	if suspendedCount == 0 {
+		t.Error("expected at least one node to be suspended")
+	}
+
+	// 自動復旧を待つ
+	time.Sleep(300 * time.Millisecond)
+
+	monkey.Stop()
+
+	// 停止後、すべてのsuspendedノードがresumeされているはず
+	for _, n := range c.Nodes() {
+		if n.Status() == node.StatusSuspended {
+			t.Error("expected all suspended nodes to be resumed after Stop")
+		}
+	}
+}
+
+func TestMonkeyAttackDelay(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.Interval = 50 * time.Millisecond
+	config.TargetCount = 1
+	config.AttackTypes = []AttackType{AttackDelay}
+	config.DelayDuration = 50 * time.Millisecond
+
+	monkey := New(c, config)
+
+	ctx := context.Background()
+	monkey.Start(ctx)
+
+	// 攻撃が発生するまで待つ
+	time.Sleep(100 * time.Millisecond)
+
+	monkey.Stop()
+
+	// ノードに遅延が設定されているはず
+	nodes := c.Nodes()
+	if len(nodes) > 0 {
+		if nodes[0].Delay() != config.DelayDuration {
+			t.Errorf("expected delay %v, got %v", config.DelayDuration, nodes[0].Delay())
+		}
+	}
+}
+
+func TestMonkeyAttackCount(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(3, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.Interval = 30 * time.Millisecond
+	config.TargetCount = 1
+	config.AttackTypes = []AttackType{AttackDelay} // Delayはノードを停止しない
+
+	monkey := New(c, config)
+
+	ctx := context.Background()
+	monkey.Start(ctx)
+
+	// 複数回の攻撃を待つ
+	time.Sleep(100 * time.Millisecond)
+
+	monkey.Stop()
+
+	if monkey.AttackCount() == 0 {
+		t.Error("expected at least one attack to be executed")
+	}
+}
+
+func TestMonkeyNoTargets(t *testing.T) {
+	c := cluster.New()
+	// ノードを追加しない
+
+	config := DefaultConfig()
+	config.Interval = 50 * time.Millisecond
+
+	monkey := New(c, config)
+
+	ctx := context.Background()
+	monkey.Start(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+
+	monkey.Stop()
+
+	// ターゲットがないので攻撃は0回
+	if monkey.AttackCount() != 0 {
+		t.Errorf("expected 0 attacks with no targets, got %d", monkey.AttackCount())
+	}
+}
+
+func TestMonkeySetConfig(t *testing.T) {
+	c := cluster.New()
+	config := DefaultConfig()
+
+	monkey := New(c, config)
+
+	newConfig := Config{
+		Interval:    1 * time.Second,
+		TargetCount: 5,
+	}
+	monkey.SetConfig(newConfig)
+
+	if monkey.config.TargetCount != 5 {
+		t.Errorf("expected target count 5, got %d", monkey.config.TargetCount)
+	}
+}

--- a/internal/chaos/doc.go
+++ b/internal/chaos/doc.go
@@ -1,0 +1,21 @@
+// Package chaos はカオスエンジニアリング機能を提供する。
+//
+// ChaosMonkeyはクラスタ内のノードに対して様々な障害を注入し、
+// システムの耐障害性をテストするために使用される。
+//
+// # 障害タイプ
+//
+// - Kill: ノードを強制停止
+// - Suspend: ノードを一時停止（リクエストを受け付けなくなる）
+// - Delay: ノードのレスポンスに遅延を注入
+//
+// # 使用例
+//
+//	config := chaos.DefaultConfig()
+//	config.Interval = 3 * time.Second
+//	config.TargetCount = 2
+//
+//	monkey := chaos.New(cluster, config)
+//	monkey.Start(ctx)
+//	defer monkey.Stop()
+package chaos


### PR DESCRIPTION
## Summary
- ChaosMonkeyパッケージを新規作成
- ノードに対する障害注入機能を実装
- Phase 3「カオス注入」の基盤

## Changes

### ChaosMonkey (`internal/chaos/`)
- **AttackType**: Kill, Suspend, Delay の3種類の障害
- **Config**: 攻撃間隔、同時攻撃対象数、遅延時間などを設定可能
- **自動復旧**: Suspend後の自動Resume機能

### Node拡張 (`internal/node/node.go`)
- `Suspend()`: ノードを一時停止
- `Resume()`: 一時停止からの復帰
- `SetDelay()` / `Delay()`: レスポンス遅延の注入

## Test plan
- [x] `make quality` パス確認
- [x] ChaosMonkeyの各障害タイプのテスト
- [x] Nodeの新メソッドのテスト

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)