### PR TITLE
feat: RecoveryManagerの実装 #32

### DIFF
--- a/internal/recovery/doc.go
+++ b/internal/recovery/doc.go
@@ -1,0 +1,22 @@
+// Package recovery はノード障害からの自動復旧機能を提供する。
+//
+// RecoveryManagerはクラスタ内のノードを監視し、
+// 障害が発生した場合に自動的に復旧を試みる。
+//
+// # 機能
+//
+// - ヘルスチェック: 定期的にノードの状態を監視
+// - 自動再起動: 停止したノードを自動的に再起動
+// - 自動再開: 一時停止中のノードを自動的に再開
+// - 遅延クリア: 復旧したノードの遅延設定をクリア
+//
+// # 使用例
+//
+//	config := recovery.DefaultConfig()
+//	config.HealthCheckInterval = 1 * time.Second
+//	config.MaxRetries = 3
+//
+//	manager := recovery.New(cluster, config)
+//	manager.Start(ctx)
+//	defer manager.Stop()
+package recovery

--- a/internal/recovery/recovery.go
+++ b/internal/recovery/recovery.go
@@ -1,0 +1,299 @@
+package recovery
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"chaos-kvs/internal/cluster"
+	"chaos-kvs/internal/logger"
+	"chaos-kvs/internal/node"
+)
+
+// Config はRecoveryManagerの設定
+type Config struct {
+	HealthCheckInterval time.Duration // ヘルスチェック間隔
+	RecoveryDelay       time.Duration // 復旧までの待機時間
+	MaxRetries          int           // 最大リトライ回数（0で無制限）
+	AutoRestart         bool          // 停止ノードの自動再起動
+	AutoResume          bool          // 一時停止ノードの自動再開
+	ClearDelay          bool          // 遅延設定のクリア
+}
+
+// DefaultConfig はデフォルト設定を返す
+func DefaultConfig() Config {
+	return Config{
+		HealthCheckInterval: 1 * time.Second,
+		RecoveryDelay:       2 * time.Second,
+		MaxRetries:          3,
+		AutoRestart:         true,
+		AutoResume:          true,
+		ClearDelay:          true,
+	}
+}
+
+// NodeState はノードの状態追跡
+type NodeState struct {
+	LastSeen    time.Time
+	FailedAt    time.Time
+	RetryCount  int
+	IsRecovered bool
+}
+
+// Stats は復旧統計
+type Stats struct {
+	TotalRecoveries   uint64
+	SuccessRecoveries uint64
+	FailedRecoveries  uint64
+	CurrentlyFailed   int
+}
+
+// Manager は障害からの復旧を管理する
+type Manager struct {
+	config  Config
+	cluster *cluster.Cluster
+
+	running atomic.Bool
+	ctx     context.Context
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+
+	mu         sync.RWMutex
+	nodeStates map[string]*NodeState
+	stats      Stats
+}
+
+// New は新しいRecoveryManagerを作成する
+func New(c *cluster.Cluster, config Config) *Manager {
+	return &Manager{
+		config:     config,
+		cluster:    c,
+		nodeStates: make(map[string]*NodeState),
+	}
+}
+
+// Start は復旧マネージャーを開始する
+func (m *Manager) Start(ctx context.Context) {
+	if m.running.Swap(true) {
+		return
+	}
+
+	m.ctx, m.cancel = context.WithCancel(ctx)
+
+	m.wg.Add(1)
+	go m.healthCheckLoop()
+
+	logger.Info("", "RecoveryManager started (interval: %v, delay: %v)",
+		m.config.HealthCheckInterval, m.config.RecoveryDelay)
+}
+
+// Stop は復旧マネージャーを停止する
+func (m *Manager) Stop() {
+	if !m.running.Swap(false) {
+		return
+	}
+
+	m.cancel()
+	m.wg.Wait()
+
+	m.mu.RLock()
+	stats := m.stats
+	m.mu.RUnlock()
+
+	logger.Info("", "RecoveryManager stopped (recoveries: %d success, %d failed)",
+		stats.SuccessRecoveries, stats.FailedRecoveries)
+}
+
+// healthCheckLoop は定期的にヘルスチェックを実行する
+func (m *Manager) healthCheckLoop() {
+	defer m.wg.Done()
+
+	ticker := time.NewTicker(m.config.HealthCheckInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-m.ctx.Done():
+			return
+		case <-ticker.C:
+			m.checkAndRecover()
+		}
+	}
+}
+
+// checkAndRecover は全ノードをチェックし、必要に応じて復旧する
+func (m *Manager) checkAndRecover() {
+	nodes := m.cluster.Nodes()
+	now := time.Now()
+
+	for _, n := range nodes {
+		m.checkNode(n, now)
+	}
+}
+
+// checkNode は個々のノードをチェックする
+func (m *Manager) checkNode(n *node.Node, now time.Time) {
+	nodeID := n.ID()
+	status := n.Status()
+
+	m.mu.Lock()
+	state, exists := m.nodeStates[nodeID]
+	if !exists {
+		state = &NodeState{LastSeen: now}
+		m.nodeStates[nodeID] = state
+	}
+	m.mu.Unlock()
+
+	switch status {
+	case node.StatusRunning:
+		m.handleRunningNode(n, state, now)
+	case node.StatusStopped:
+		m.handleStoppedNode(n, state, now)
+	case node.StatusSuspended:
+		m.handleSuspendedNode(n, state, now)
+	}
+}
+
+// handleRunningNode は稼働中のノードを処理する
+func (m *Manager) handleRunningNode(n *node.Node, state *NodeState, now time.Time) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// 遅延クリア
+	if m.config.ClearDelay && n.Delay() > 0 {
+		n.SetDelay(0)
+		logger.Info("", "RecoveryManager: cleared delay on node %s", n.ID())
+	}
+
+	// 復旧完了を記録
+	if !state.IsRecovered && state.RetryCount > 0 {
+		state.IsRecovered = true
+		m.stats.SuccessRecoveries++
+		logger.Info("", "RecoveryManager: node %s recovered successfully", n.ID())
+	}
+
+	state.LastSeen = now
+	state.RetryCount = 0
+	state.IsRecovered = false
+}
+
+// handleStoppedNode は停止したノードを処理する
+func (m *Manager) handleStoppedNode(n *node.Node, state *NodeState, now time.Time) {
+	if !m.config.AutoRestart {
+		return
+	}
+
+	m.mu.Lock()
+
+	// 初回検出
+	if state.FailedAt.IsZero() {
+		state.FailedAt = now
+		m.stats.CurrentlyFailed++
+		m.mu.Unlock()
+		logger.Warn("", "RecoveryManager: detected stopped node %s", n.ID())
+		return
+	}
+
+	// 復旧待機時間チェック
+	if now.Sub(state.FailedAt) < m.config.RecoveryDelay {
+		m.mu.Unlock()
+		return
+	}
+
+	// リトライ上限チェック
+	if m.config.MaxRetries > 0 && state.RetryCount >= m.config.MaxRetries {
+		m.mu.Unlock()
+		return
+	}
+
+	state.RetryCount++
+	state.FailedAt = now
+	m.stats.TotalRecoveries++
+	m.mu.Unlock()
+
+	// 再起動を試みる
+	if err := n.Start(m.ctx); err != nil {
+		m.mu.Lock()
+		m.stats.FailedRecoveries++
+		m.mu.Unlock()
+		logger.Error("", "RecoveryManager: failed to restart node %s: %v", n.ID(), err)
+		return
+	}
+
+	m.mu.Lock()
+	m.stats.CurrentlyFailed--
+	state.FailedAt = time.Time{}
+	m.mu.Unlock()
+
+	logger.Info("", "RecoveryManager: restarted node %s (attempt %d)", n.ID(), state.RetryCount)
+}
+
+// handleSuspendedNode は一時停止中のノードを処理する
+func (m *Manager) handleSuspendedNode(n *node.Node, state *NodeState, now time.Time) {
+	if !m.config.AutoResume {
+		return
+	}
+
+	m.mu.Lock()
+
+	// 初回検出
+	if state.FailedAt.IsZero() {
+		state.FailedAt = now
+		m.mu.Unlock()
+		logger.Warn("", "RecoveryManager: detected suspended node %s", n.ID())
+		return
+	}
+
+	// 復旧待機時間チェック
+	if now.Sub(state.FailedAt) < m.config.RecoveryDelay {
+		m.mu.Unlock()
+		return
+	}
+
+	state.RetryCount++
+	state.FailedAt = time.Time{}
+	m.stats.TotalRecoveries++
+	m.mu.Unlock()
+
+	// 再開を試みる
+	if err := n.Resume(); err != nil {
+		m.mu.Lock()
+		m.stats.FailedRecoveries++
+		m.mu.Unlock()
+		logger.Error("", "RecoveryManager: failed to resume node %s: %v", n.ID(), err)
+		return
+	}
+
+	m.mu.Lock()
+	m.stats.SuccessRecoveries++
+	m.mu.Unlock()
+
+	logger.Info("", "RecoveryManager: resumed node %s", n.ID())
+}
+
+// IsRunning は実行中かどうかを返す
+func (m *Manager) IsRunning() bool {
+	return m.running.Load()
+}
+
+// Stats は復旧統計を返す
+func (m *Manager) Stats() Stats {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.stats
+}
+
+// SetConfig は設定を更新する
+func (m *Manager) SetConfig(config Config) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.config = config
+}
+
+// ResetStats は統計をリセットする
+func (m *Manager) ResetStats() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.stats = Stats{}
+}

--- a/internal/recovery/recovery_test.go
+++ b/internal/recovery/recovery_test.go
@@ -1,0 +1,338 @@
+package recovery
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"chaos-kvs/internal/cluster"
+	"chaos-kvs/internal/node"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	if config.HealthCheckInterval != 1*time.Second {
+		t.Errorf("expected interval 1s, got %v", config.HealthCheckInterval)
+	}
+	if config.RecoveryDelay != 2*time.Second {
+		t.Errorf("expected recovery delay 2s, got %v", config.RecoveryDelay)
+	}
+	if config.MaxRetries != 3 {
+		t.Errorf("expected max retries 3, got %d", config.MaxRetries)
+	}
+	if !config.AutoRestart {
+		t.Error("expected auto restart to be true")
+	}
+	if !config.AutoResume {
+		t.Error("expected auto resume to be true")
+	}
+}
+
+func TestNewManager(t *testing.T) {
+	c := cluster.New()
+	config := DefaultConfig()
+
+	manager := New(c, config)
+
+	if manager == nil {
+		t.Fatal("expected non-nil manager")
+	}
+	if manager.IsRunning() {
+		t.Error("expected manager to not be running initially")
+	}
+}
+
+func TestManagerStartStop(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(3, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+
+	if !manager.IsRunning() {
+		t.Error("expected manager to be running after Start")
+	}
+
+	// 少し待ってから停止
+	time.Sleep(100 * time.Millisecond)
+
+	manager.Stop()
+
+	if manager.IsRunning() {
+		t.Error("expected manager to not be running after Stop")
+	}
+}
+
+func TestManagerAutoRestart(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+	config.RecoveryDelay = 100 * time.Millisecond
+	config.AutoRestart = true
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	// ノードを停止
+	nodes := c.Nodes()
+	if len(nodes) == 0 {
+		t.Fatal("expected at least one node")
+	}
+	_ = nodes[0].Stop()
+
+	if nodes[0].Status() != node.StatusStopped {
+		t.Error("expected node to be stopped")
+	}
+
+	// 自動復旧を待つ
+	time.Sleep(300 * time.Millisecond)
+
+	if nodes[0].Status() != node.StatusRunning {
+		t.Errorf("expected node to be running after recovery, got %v", nodes[0].Status())
+	}
+}
+
+func TestManagerAutoResume(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+	config.RecoveryDelay = 100 * time.Millisecond
+	config.AutoResume = true
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	// ノードをsuspend
+	nodes := c.Nodes()
+	if len(nodes) == 0 {
+		t.Fatal("expected at least one node")
+	}
+	_ = nodes[0].Suspend()
+
+	if nodes[0].Status() != node.StatusSuspended {
+		t.Error("expected node to be suspended")
+	}
+
+	// 自動復旧を待つ
+	time.Sleep(300 * time.Millisecond)
+
+	if nodes[0].Status() != node.StatusRunning {
+		t.Errorf("expected node to be running after recovery, got %v", nodes[0].Status())
+	}
+}
+
+func TestManagerClearDelay(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+	config.ClearDelay = true
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	// ノードに遅延を設定
+	nodes := c.Nodes()
+	if len(nodes) == 0 {
+		t.Fatal("expected at least one node")
+	}
+	nodes[0].SetDelay(100 * time.Millisecond)
+
+	if nodes[0].Delay() != 100*time.Millisecond {
+		t.Error("expected delay to be set")
+	}
+
+	// 遅延クリアを待つ
+	time.Sleep(150 * time.Millisecond)
+
+	if nodes[0].Delay() != 0 {
+		t.Error("expected delay to be cleared")
+	}
+}
+
+func TestManagerMaxRetries(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 30 * time.Millisecond
+	config.RecoveryDelay = 50 * time.Millisecond
+	config.MaxRetries = 2
+	config.AutoRestart = true
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	nodes := c.Nodes()
+	if len(nodes) == 0 {
+		t.Fatal("expected at least one node")
+	}
+
+	// ノードを停止（再起動されても再度停止される場合をシミュレート）
+	_ = nodes[0].Stop()
+
+	// 複数回のリトライを待つ
+	time.Sleep(400 * time.Millisecond)
+
+	stats := manager.Stats()
+	if stats.TotalRecoveries == 0 {
+		t.Error("expected at least one recovery attempt")
+	}
+}
+
+func TestManagerStats(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+	config.RecoveryDelay = 100 * time.Millisecond
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	// ノードをsuspend
+	nodes := c.Nodes()
+	_ = nodes[0].Suspend()
+
+	// 復旧を待つ
+	time.Sleep(300 * time.Millisecond)
+
+	stats := manager.Stats()
+	if stats.TotalRecoveries == 0 {
+		t.Error("expected total recoveries > 0")
+	}
+}
+
+func TestManagerSetConfig(t *testing.T) {
+	c := cluster.New()
+	config := DefaultConfig()
+
+	manager := New(c, config)
+
+	newConfig := Config{
+		HealthCheckInterval: 5 * time.Second,
+		MaxRetries:          10,
+	}
+	manager.SetConfig(newConfig)
+
+	if manager.config.MaxRetries != 10 {
+		t.Errorf("expected max retries 10, got %d", manager.config.MaxRetries)
+	}
+}
+
+func TestManagerResetStats(t *testing.T) {
+	c := cluster.New()
+	config := DefaultConfig()
+
+	manager := New(c, config)
+
+	// 手動で統計を設定
+	manager.mu.Lock()
+	manager.stats.TotalRecoveries = 10
+	manager.stats.SuccessRecoveries = 8
+	manager.mu.Unlock()
+
+	manager.ResetStats()
+
+	stats := manager.Stats()
+	if stats.TotalRecoveries != 0 {
+		t.Error("expected stats to be reset")
+	}
+}
+
+func TestManagerDisabledAutoRestart(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+	config.RecoveryDelay = 50 * time.Millisecond
+	config.AutoRestart = false
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	// ノードを停止
+	nodes := c.Nodes()
+	_ = nodes[0].Stop()
+
+	// 待機しても復旧しないはず
+	time.Sleep(200 * time.Millisecond)
+
+	if nodes[0].Status() != node.StatusStopped {
+		t.Error("expected node to remain stopped when AutoRestart is disabled")
+	}
+}
+
+func TestManagerDisabledAutoResume(t *testing.T) {
+	c := cluster.New()
+	_ = c.CreateNodes(1, "node")
+	_ = c.StartAll(context.Background())
+	defer func() { _ = c.StopAll() }()
+
+	config := DefaultConfig()
+	config.HealthCheckInterval = 50 * time.Millisecond
+	config.RecoveryDelay = 50 * time.Millisecond
+	config.AutoResume = false
+
+	manager := New(c, config)
+
+	ctx := context.Background()
+	manager.Start(ctx)
+	defer manager.Stop()
+
+	// ノードをsuspend
+	nodes := c.Nodes()
+	_ = nodes[0].Suspend()
+
+	// 待機しても復旧しないはず
+	time.Sleep(200 * time.Millisecond)
+
+	if nodes[0].Status() != node.StatusSuspended {
+		t.Error("expected node to remain suspended when AutoResume is disabled")
+	}
+}


### PR DESCRIPTION
## Summary
- ノード障害からの自動復旧機能（RecoveryManager）を実装
- 定期的なヘルスチェックで停止・一時停止ノードを検出
- 自動再起動・再開・遅延クリア機能を提供

## 機能詳細
- `HealthCheckInterval`: ヘルスチェック間隔（デフォルト1秒）
- `RecoveryDelay`: 復旧までの待機時間（デフォルト2秒）
- `MaxRetries`: 最大リトライ回数（デフォルト3回、0で無制限）
- `AutoRestart`: 停止ノードの自動再起動
- `AutoResume`: 一時停止ノードの自動再開
- `ClearDelay`: 遅延設定のクリア

## Test plan
- [x] `TestManagerStartStop`: 起動・停止の動作確認
- [x] `TestManagerAutoRestart`: 自動再起動のテスト
- [x] `TestManagerAutoResume`: 自動再開のテスト
- [x] `TestManagerClearDelay`: 遅延クリアのテスト
- [x] `TestManagerMaxRetries`: リトライ制限のテスト
- [x] `TestManagerDisabledAutoRestart`: 無効化時のテスト
- [x] `TestManagerDisabledAutoResume`: 無効化時のテスト

closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)