### PR TITLE
feat: カオス可視化機能の実装

### DIFF
--- a/internal/api/static/index.html
+++ b/internal/api/static/index.html
@@ -43,42 +43,43 @@
             color: white;
         }
         .container {
-            max-width: 1200px;
+            max-width: 1400px;
             margin: 0 auto;
             padding: 2rem;
         }
         .grid {
             display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-            gap: 1.5rem;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 1rem;
             margin-bottom: 2rem;
         }
         .card {
             background: #16213e;
             border-radius: 12px;
-            padding: 1.5rem;
+            padding: 1.25rem;
             border: 1px solid #0f3460;
         }
         .card h2 {
-            font-size: 0.875rem;
+            font-size: 0.75rem;
             color: #9ca3af;
             margin-bottom: 0.5rem;
             text-transform: uppercase;
             letter-spacing: 0.05em;
         }
         .card .value {
-            font-size: 2rem;
+            font-size: 1.75rem;
             font-weight: bold;
             color: #e94560;
         }
         .card .value.green { color: #10b981; }
         .card .value.yellow { color: #f59e0b; }
         .card .value.red { color: #ef4444; }
+        .card .value.blue { color: #3b82f6; }
         .section {
             background: #16213e;
             border-radius: 12px;
             padding: 1.5rem;
-            margin-bottom: 2rem;
+            margin-bottom: 1.5rem;
             border: 1px solid #0f3460;
         }
         .section h2 {
@@ -127,60 +128,144 @@
         button.secondary:hover {
             background: #16213e;
         }
+        .two-columns {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1.5rem;
+        }
+        @media (max-width: 900px) {
+            .two-columns {
+                grid-template-columns: 1fr;
+            }
+        }
         .nodes-grid {
             display: grid;
-            grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-            gap: 1rem;
+            grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+            gap: 0.75rem;
         }
         .node {
             background: #1a1a2e;
             border-radius: 8px;
-            padding: 1rem;
+            padding: 0.75rem;
             text-align: center;
             border: 2px solid transparent;
+            transition: all 0.3s ease;
+            position: relative;
         }
         .node.running { border-color: #10b981; }
         .node.stopped { border-color: #ef4444; }
         .node.suspended { border-color: #f59e0b; }
         .node .id {
             font-weight: bold;
-            margin-bottom: 0.5rem;
+            font-size: 0.875rem;
+            margin-bottom: 0.25rem;
         }
         .node .status {
-            font-size: 0.75rem;
+            font-size: 0.7rem;
             text-transform: uppercase;
             letter-spacing: 0.05em;
         }
         .node .status.running { color: #10b981; }
         .node .status.stopped { color: #ef4444; }
         .node .status.suspended { color: #f59e0b; }
+        .node .icon {
+            position: absolute;
+            top: -8px;
+            right: -8px;
+            font-size: 1.25rem;
+        }
+        /* Attack animations */
+        @keyframes attack-flash {
+            0% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0.8); transform: scale(1); }
+            50% { box-shadow: 0 0 20px 10px rgba(239, 68, 68, 0.4); transform: scale(1.05); }
+            100% { box-shadow: 0 0 0 0 rgba(239, 68, 68, 0); transform: scale(1); }
+        }
+        @keyframes suspend-pulse {
+            0% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0.8); }
+            50% { box-shadow: 0 0 15px 8px rgba(245, 158, 11, 0.4); }
+            100% { box-shadow: 0 0 0 0 rgba(245, 158, 11, 0); }
+        }
+        @keyframes delay-glow {
+            0% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0.8); }
+            50% { box-shadow: 0 0 15px 8px rgba(59, 130, 246, 0.4); }
+            100% { box-shadow: 0 0 0 0 rgba(59, 130, 246, 0); }
+        }
+        @keyframes recovery-glow {
+            0% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0.8); }
+            50% { box-shadow: 0 0 20px 10px rgba(16, 185, 129, 0.4); }
+            100% { box-shadow: 0 0 0 0 rgba(16, 185, 129, 0); }
+        }
+        .node.attack-kill { animation: attack-flash 0.5s ease-out; }
+        .node.attack-suspend { animation: suspend-pulse 0.5s ease-out; }
+        .node.attack-delay { animation: delay-glow 0.5s ease-out; }
+        .node.recovery { animation: recovery-glow 0.6s ease-out; }
+        /* Timeline */
+        .timeline {
+            background: #0d1117;
+            border-radius: 8px;
+            padding: 1rem;
+            max-height: 300px;
+            overflow-y: auto;
+        }
+        .timeline-entry {
+            display: flex;
+            align-items: center;
+            gap: 0.75rem;
+            padding: 0.5rem;
+            border-radius: 6px;
+            margin-bottom: 0.5rem;
+            background: #1a1a2e;
+            font-size: 0.875rem;
+        }
+        .timeline-entry:last-child { margin-bottom: 0; }
+        .timeline-entry .icon { font-size: 1.25rem; }
+        .timeline-entry .time { color: #6b7280; font-size: 0.75rem; min-width: 70px; }
+        .timeline-entry .node-id { color: #e94560; font-weight: bold; }
+        .timeline-entry.kill { border-left: 3px solid #ef4444; }
+        .timeline-entry.suspend { border-left: 3px solid #f59e0b; }
+        .timeline-entry.delay { border-left: 3px solid #3b82f6; }
+        .timeline-entry.resume { border-left: 3px solid #10b981; }
+        .timeline-entry.recovery-start { border-left: 3px solid #8b5cf6; }
+        .timeline-entry.recovery-success { border-left: 3px solid #10b981; }
+        .timeline-entry.recovery-failed { border-left: 3px solid #ef4444; }
+        /* Attack distribution */
+        .attack-distribution {
+            display: flex;
+            gap: 0.5rem;
+            margin-top: 0.5rem;
+        }
+        .attack-bar {
+            padding: 0.5rem 0.75rem;
+            border-radius: 6px;
+            font-size: 0.75rem;
+            font-weight: bold;
+            text-align: center;
+            flex: 1;
+        }
+        .attack-bar.kill { background: rgba(239, 68, 68, 0.2); color: #ef4444; }
+        .attack-bar.suspend { background: rgba(245, 158, 11, 0.2); color: #f59e0b; }
+        .attack-bar.delay { background: rgba(59, 130, 246, 0.2); color: #3b82f6; }
+        /* Log */
         .log {
             background: #0d1117;
             border-radius: 8px;
             padding: 1rem;
             font-family: monospace;
-            font-size: 0.875rem;
-            max-height: 200px;
+            font-size: 0.8rem;
+            max-height: 150px;
             overflow-y: auto;
         }
         .log-entry {
-            padding: 0.25rem 0;
+            padding: 0.2rem 0;
             border-bottom: 1px solid #1a1a2e;
         }
-        .log-entry:last-child {
-            border-bottom: none;
-        }
-        .log-entry .time {
-            color: #6b7280;
-            margin-right: 0.5rem;
-        }
+        .log-entry:last-child { border-bottom: none; }
+        .log-entry .time { color: #6b7280; margin-right: 0.5rem; }
         @keyframes pulse {
             0%, 100% { opacity: 1; }
             50% { opacity: 0.5; }
         }
-        .pulse {
-            animation: pulse 2s infinite;
-        }
+        .pulse { animation: pulse 2s infinite; }
     </style>
 </head>
 <body>
@@ -190,6 +275,7 @@
     </header>
 
     <div class="container">
+        <!-- Metrics Cards -->
         <div class="grid">
             <div class="card">
                 <h2>Total Requests</h2>
@@ -207,35 +293,64 @@
                 <h2>Avg Latency</h2>
                 <div id="avgLatency" class="value">0ms</div>
             </div>
+            <div class="card">
+                <h2>Total Attacks</h2>
+                <div id="totalAttacks" class="value red">0</div>
+            </div>
+            <div class="card">
+                <h2>Recoveries</h2>
+                <div id="recoveries" class="value blue">0/0</div>
+            </div>
         </div>
 
+        <!-- Scenario Control -->
         <div class="section">
             <h2>Scenario Control</h2>
             <div class="controls">
                 <select id="presetSelect">
                     <option value="quick">Quick (5s)</option>
                     <option value="basic">Basic</option>
-                    <option value="resilience">Resilience</option>
+                    <option value="resilience" selected>Resilience</option>
                     <option value="latency">Latency</option>
                     <option value="stress">Stress</option>
                 </select>
-                <input type="text" id="duration" placeholder="Duration (e.g. 10s)" style="width: 150px;">
-                <input type="number" id="nodes" placeholder="Nodes" min="1" max="20" style="width: 100px;">
+                <input type="text" id="duration" placeholder="Duration (e.g. 30s)" style="width: 150px;">
+                <input type="number" id="nodes" placeholder="Nodes" min="1" max="20" style="width: 100px;" value="5">
                 <button id="startBtn" onclick="startScenario()">Start</button>
                 <button id="stopBtn" class="secondary" onclick="stopScenario()" disabled>Stop</button>
             </div>
         </div>
 
-        <div class="section">
-            <h2>Nodes</h2>
-            <div id="nodesGrid" class="nodes-grid">
-                <div class="node">
-                    <div class="id">-</div>
-                    <div class="status">No nodes</div>
+        <div class="two-columns">
+            <!-- Nodes -->
+            <div class="section">
+                <h2>Nodes</h2>
+                <div id="nodesGrid" class="nodes-grid">
+                    <div class="node">
+                        <div class="id">-</div>
+                        <div class="status">No nodes</div>
+                    </div>
+                </div>
+                <div id="attackDistribution" class="attack-distribution" style="display: none;">
+                    <div class="attack-bar kill" id="killBar">Kill: 0</div>
+                    <div class="attack-bar suspend" id="suspendBar">Suspend: 0</div>
+                    <div class="attack-bar delay" id="delayBar">Delay: 0</div>
+                </div>
+            </div>
+
+            <!-- Chaos Timeline -->
+            <div class="section">
+                <h2>Chaos Timeline</h2>
+                <div id="chaosTimeline" class="timeline">
+                    <div class="timeline-entry" style="opacity: 0.5;">
+                        <span class="icon">...</span>
+                        <span>Waiting for chaos events...</span>
+                    </div>
                 </div>
             </div>
         </div>
 
+        <!-- Activity Log -->
         <div class="section">
             <h2>Activity Log</h2>
             <div id="log" class="log">
@@ -250,6 +365,8 @@
     <script>
         let ws = null;
         let isRunning = false;
+        let timelineEvents = [];
+        const MAX_TIMELINE_EVENTS = 50;
 
         function connectWebSocket() {
             const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
@@ -277,13 +394,157 @@
         function handleMessage(data) {
             if (data.type === 'status') {
                 updateStatus(data.status);
+                if (data.chaos_stats) updateChaosStats(data.chaos_stats);
+                if (data.recovery_stats) updateRecoveryStats(data.recovery_stats);
+                if (data.metrics) updateMetrics(data.metrics);
+            } else if (data.type === 'event') {
+                handleChaosEvent(data.event);
             } else if (data.type === 'scenario_complete') {
                 isRunning = false;
                 updateUI();
                 if (data.result) {
-                    addLog(`Scenario completed: ${data.result.TotalRequests} requests`);
+                    addLog(`Scenario completed: ${data.result.TotalRequests} requests, ${data.result.TotalAttacks} attacks`);
                 }
             }
+        }
+
+        function handleChaosEvent(event) {
+            addTimelineEntry(event);
+            animateNode(event.node_id, event.type, event.data);
+        }
+
+        function addTimelineEntry(event) {
+            const timeline = document.getElementById('chaosTimeline');
+            const time = new Date(event.timestamp).toLocaleTimeString();
+
+            let icon, message, cssClass;
+
+            switch(event.type) {
+                case 'chaos_attack':
+                    const attackType = event.data?.attack_type || 'unknown';
+                    if (attackType === 'kill') {
+                        icon = '💀'; message = 'killed'; cssClass = 'kill';
+                    } else if (attackType === 'suspend') {
+                        icon = '⏸️'; message = 'suspended'; cssClass = 'suspend';
+                    } else if (attackType === 'delay') {
+                        const delay = event.data?.delay_duration || '';
+                        icon = '🕐'; message = `delay +${delay}`; cssClass = 'delay';
+                    }
+                    break;
+                case 'chaos_resume':
+                    icon = '▶️'; message = 'auto-resumed'; cssClass = 'resume';
+                    break;
+                case 'recovery_start':
+                    icon = '🔧'; message = `recovery attempt #${event.data?.attempt || 1}`; cssClass = 'recovery-start';
+                    break;
+                case 'recovery_success':
+                    icon = '✅'; message = 'recovered'; cssClass = 'recovery-success';
+                    break;
+                case 'recovery_failed':
+                    icon = '❌'; message = 'recovery failed'; cssClass = 'recovery-failed';
+                    break;
+                default:
+                    icon = '📝'; message = event.type; cssClass = '';
+            }
+
+            const entry = document.createElement('div');
+            entry.className = `timeline-entry ${cssClass}`;
+            entry.innerHTML = `
+                <span class="icon">${icon}</span>
+                <span class="time">${time}</span>
+                <span class="node-id">${event.node_id}</span>
+                <span>${message}</span>
+            `;
+
+            // Remove placeholder if exists
+            const placeholder = timeline.querySelector('.timeline-entry[style*="opacity"]');
+            if (placeholder) placeholder.remove();
+
+            timeline.insertBefore(entry, timeline.firstChild);
+
+            // Keep only last N entries
+            while (timeline.children.length > MAX_TIMELINE_EVENTS) {
+                timeline.removeChild(timeline.lastChild);
+            }
+        }
+
+        function animateNode(nodeId, eventType, data) {
+            const nodes = document.querySelectorAll('.node');
+            nodes.forEach(node => {
+                if (node.querySelector('.id')?.textContent === nodeId) {
+                    // Remove existing animation classes
+                    node.classList.remove('attack-kill', 'attack-suspend', 'attack-delay', 'recovery');
+
+                    // Add appropriate animation
+                    if (eventType === 'chaos_attack') {
+                        const attackType = data?.attack_type || 'kill';
+                        node.classList.add(`attack-${attackType}`);
+
+                        // Show icon temporarily
+                        let icon;
+                        if (attackType === 'kill') icon = '💀';
+                        else if (attackType === 'suspend') icon = '⏸️';
+                        else if (attackType === 'delay') icon = '🕐';
+
+                        if (icon) {
+                            const iconEl = document.createElement('span');
+                            iconEl.className = 'icon';
+                            iconEl.textContent = icon;
+                            node.appendChild(iconEl);
+                            setTimeout(() => iconEl.remove(), 2000);
+                        }
+                    } else if (eventType === 'recovery_success' || eventType === 'chaos_resume') {
+                        node.classList.add('recovery');
+                        const iconEl = document.createElement('span');
+                        iconEl.className = 'icon';
+                        iconEl.textContent = '✅';
+                        node.appendChild(iconEl);
+                        setTimeout(() => iconEl.remove(), 2000);
+                    }
+
+                    // Remove animation class after animation completes
+                    setTimeout(() => {
+                        node.classList.remove('attack-kill', 'attack-suspend', 'attack-delay', 'recovery');
+                    }, 600);
+                }
+            });
+        }
+
+        function updateMetrics(metrics) {
+            document.getElementById('totalRequests').textContent = formatNumber(metrics.total_requests);
+            document.getElementById('rps').textContent = metrics.rps.toFixed(1);
+
+            const errorRate = (metrics.error_rate * 100).toFixed(2);
+            const errorRateEl = document.getElementById('errorRate');
+            errorRateEl.textContent = `${errorRate}%`;
+            errorRateEl.className = `value ${errorRate > 5 ? 'red' : errorRate > 1 ? 'yellow' : 'green'}`;
+
+            document.getElementById('avgLatency').textContent = `${metrics.avg_latency_ms.toFixed(2)}ms`;
+        }
+
+        function updateChaosStats(stats) {
+            document.getElementById('totalAttacks').textContent = stats.total_attacks || 0;
+
+            const byType = stats.attacks_by_type || {};
+            document.getElementById('killBar').textContent = `Kill: ${byType.kill || 0}`;
+            document.getElementById('suspendBar').textContent = `Suspend: ${byType.suspend || 0}`;
+            document.getElementById('delayBar').textContent = `Delay: ${byType.delay || 0}`;
+
+            if (stats.total_attacks > 0) {
+                document.getElementById('attackDistribution').style.display = 'flex';
+            }
+        }
+
+        function updateRecoveryStats(stats) {
+            const success = stats.SuccessRecoveries || 0;
+            const total = stats.TotalRecoveries || 0;
+            document.getElementById('recoveries').textContent = `${success}/${total}`;
+        }
+
+        function formatNumber(n) {
+            if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+            if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+            return n.toString();
         }
 
         function updateStatus(status) {
@@ -321,6 +582,10 @@
             const body = { preset };
             if (duration) body.duration = duration;
             if (nodes) body.nodes = parseInt(nodes);
+
+            // Clear timeline
+            document.getElementById('chaosTimeline').innerHTML = '';
+            document.getElementById('attackDistribution').style.display = 'none';
 
             try {
                 const resp = await fetch('/api/scenario/start', {
@@ -384,10 +649,10 @@
             }
 
             grid.innerHTML = nodes.map(n => `
-                <div class="node ${n.status.toLowerCase()}">
+                <div class="node ${n.status.toLowerCase()}" data-node-id="${n.id}">
                     <div class="id">${n.id}</div>
                     <div class="status ${n.status.toLowerCase()}">${n.status}</div>
-                    ${n.delay ? `<div style="font-size: 0.75rem; color: #f59e0b;">+${n.delay}</div>` : ''}
+                    ${n.delay ? `<div style="font-size: 0.7rem; color: #3b82f6;">+${n.delay}</div>` : ''}
                 </div>
             `).join('');
         }
@@ -400,13 +665,11 @@
             entry.innerHTML = `<span class="time">${time}</span><span>${message}</span>`;
             log.insertBefore(entry, log.firstChild);
 
-            // Keep only last 50 entries
-            while (log.children.length > 50) {
+            while (log.children.length > 30) {
                 log.removeChild(log.lastChild);
             }
         }
 
-        // Initial load
         async function init() {
             try {
                 const resp = await fetch('/api/status');

--- a/internal/events/bus.go
+++ b/internal/events/bus.go
@@ -1,0 +1,80 @@
+package events
+
+import (
+	"sync"
+)
+
+const defaultBufferSize = 100
+
+// Bus is a simple pub/sub event bus
+type Bus struct {
+	mu          sync.RWMutex
+	subscribers map[chan Event]struct{}
+	bufferSize  int
+}
+
+// NewBus creates a new event bus
+func NewBus() *Bus {
+	return &Bus{
+		subscribers: make(map[chan Event]struct{}),
+		bufferSize:  defaultBufferSize,
+	}
+}
+
+// Subscribe returns a channel that receives events
+func (b *Bus) Subscribe() <-chan Event {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	ch := make(chan Event, b.bufferSize)
+	b.subscribers[ch] = struct{}{}
+	return ch
+}
+
+// Unsubscribe removes a subscriber channel
+func (b *Bus) Unsubscribe(ch <-chan Event) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	// Find and remove the channel
+	for sub := range b.subscribers {
+		if sub == ch {
+			delete(b.subscribers, sub)
+			close(sub)
+			return
+		}
+	}
+}
+
+// Publish sends an event to all subscribers
+// Non-blocking: if a subscriber's buffer is full, the event is dropped for that subscriber
+func (b *Bus) Publish(event Event) {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+
+	for ch := range b.subscribers {
+		select {
+		case ch <- event:
+		default:
+			// Channel full, drop event for this subscriber
+		}
+	}
+}
+
+// SubscriberCount returns the number of active subscribers
+func (b *Bus) SubscriberCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subscribers)
+}
+
+// Close closes all subscriber channels
+func (b *Bus) Close() {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	for ch := range b.subscribers {
+		close(ch)
+		delete(b.subscribers, ch)
+	}
+}

--- a/internal/events/bus_test.go
+++ b/internal/events/bus_test.go
@@ -1,0 +1,167 @@
+package events
+
+import (
+	"testing"
+	"time"
+)
+
+func TestNewBus(t *testing.T) {
+	bus := NewBus()
+	if bus == nil {
+		t.Fatal("expected non-nil bus")
+	}
+	if bus.SubscriberCount() != 0 {
+		t.Errorf("expected 0 subscribers, got %d", bus.SubscriberCount())
+	}
+}
+
+func TestBusSubscribe(t *testing.T) {
+	bus := NewBus()
+
+	ch1 := bus.Subscribe()
+	if bus.SubscriberCount() != 1 {
+		t.Errorf("expected 1 subscriber, got %d", bus.SubscriberCount())
+	}
+
+	ch2 := bus.Subscribe()
+	if bus.SubscriberCount() != 2 {
+		t.Errorf("expected 2 subscribers, got %d", bus.SubscriberCount())
+	}
+
+	if ch1 == nil || ch2 == nil {
+		t.Error("expected non-nil channels")
+	}
+}
+
+func TestBusUnsubscribe(t *testing.T) {
+	bus := NewBus()
+
+	ch := bus.Subscribe()
+	if bus.SubscriberCount() != 1 {
+		t.Errorf("expected 1 subscriber, got %d", bus.SubscriberCount())
+	}
+
+	bus.Unsubscribe(ch)
+	if bus.SubscriberCount() != 0 {
+		t.Errorf("expected 0 subscribers, got %d", bus.SubscriberCount())
+	}
+}
+
+func TestBusPublish(t *testing.T) {
+	bus := NewBus()
+
+	ch := bus.Subscribe()
+
+	event := NewChaosAttackEvent("node-1", AttackTypeKill)
+	bus.Publish(event)
+
+	select {
+	case received := <-ch:
+		if received.Type != EventChaosAttack {
+			t.Errorf("expected type %s, got %s", EventChaosAttack, received.Type)
+		}
+		if received.NodeID != "node-1" {
+			t.Errorf("expected node-1, got %s", received.NodeID)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout waiting for event")
+	}
+}
+
+func TestBusPublishMultipleSubscribers(t *testing.T) {
+	bus := NewBus()
+
+	ch1 := bus.Subscribe()
+	ch2 := bus.Subscribe()
+
+	event := NewChaosAttackEvent("node-1", AttackTypeSuspend)
+	bus.Publish(event)
+
+	for i, ch := range []<-chan Event{ch1, ch2} {
+		select {
+		case received := <-ch:
+			if received.Type != EventChaosAttack {
+				t.Errorf("subscriber %d: expected type %s, got %s", i, EventChaosAttack, received.Type)
+			}
+		case <-time.After(100 * time.Millisecond):
+			t.Errorf("subscriber %d: timeout waiting for event", i)
+		}
+	}
+}
+
+func TestBusPublishNonBlocking(t *testing.T) {
+	bus := NewBus()
+	bus.bufferSize = 1 // Small buffer for testing
+
+	ch := bus.Subscribe()
+
+	// Fill the buffer
+	bus.Publish(NewChaosAttackEvent("node-1", AttackTypeKill))
+	bus.Publish(NewChaosAttackEvent("node-2", AttackTypeKill))
+	bus.Publish(NewChaosAttackEvent("node-3", AttackTypeKill))
+
+	// Should not block - test passes if it completes
+	// First event should be received
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+		t.Error("timeout waiting for first event")
+	}
+}
+
+func TestBusClose(t *testing.T) {
+	bus := NewBus()
+
+	ch := bus.Subscribe()
+	bus.Close()
+
+	if bus.SubscriberCount() != 0 {
+		t.Errorf("expected 0 subscribers after close, got %d", bus.SubscriberCount())
+	}
+
+	// Channel should be closed
+	_, ok := <-ch
+	if ok {
+		t.Error("expected channel to be closed")
+	}
+}
+
+func TestEventCreation(t *testing.T) {
+	t.Run("ChaosAttackEvent", func(t *testing.T) {
+		event := NewChaosAttackEvent("node-1", AttackTypeKill)
+		if event.Type != EventChaosAttack {
+			t.Errorf("expected %s, got %s", EventChaosAttack, event.Type)
+		}
+		if event.NodeID != "node-1" {
+			t.Errorf("expected node-1, got %s", event.NodeID)
+		}
+		if event.Data.AttackType != AttackTypeKill {
+			t.Errorf("expected kill, got %s", event.Data.AttackType)
+		}
+	})
+
+	t.Run("ChaosAttackEventWithDelay", func(t *testing.T) {
+		event := NewChaosAttackEventWithDelay("node-2", 100*time.Millisecond)
+		if event.Data.AttackType != AttackTypeDelay {
+			t.Errorf("expected delay, got %s", event.Data.AttackType)
+		}
+		if event.Data.DelayDuration != "100ms" {
+			t.Errorf("expected 100ms, got %s", event.Data.DelayDuration)
+		}
+	})
+
+	t.Run("RecoveryEvents", func(t *testing.T) {
+		start := NewRecoveryStartEvent("node-1", 1)
+		if start.Type != EventRecoveryStart {
+			t.Errorf("expected %s, got %s", EventRecoveryStart, start.Type)
+		}
+		if start.Data.Attempt != 1 {
+			t.Errorf("expected attempt 1, got %d", start.Data.Attempt)
+		}
+
+		success := NewRecoverySuccessEvent("node-1")
+		if success.Type != EventRecoverySuccess {
+			t.Errorf("expected %s, got %s", EventRecoverySuccess, success.Type)
+		}
+	})
+}

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -1,0 +1,116 @@
+// Package events provides an event system for chaos and recovery notifications.
+package events
+
+import "time"
+
+// EventType represents the type of event
+type EventType string
+
+const (
+	// EventChaosAttack is emitted when a chaos attack is executed
+	EventChaosAttack EventType = "chaos_attack"
+	// EventChaosResume is emitted when a suspended node is auto-resumed by chaos
+	EventChaosResume EventType = "chaos_resume"
+	// EventRecoveryStart is emitted when recovery attempts to restore a node
+	EventRecoveryStart EventType = "recovery_start"
+	// EventRecoverySuccess is emitted when recovery successfully restores a node
+	EventRecoverySuccess EventType = "recovery_success"
+	// EventRecoveryFailed is emitted when recovery fails to restore a node
+	EventRecoveryFailed EventType = "recovery_failed"
+)
+
+// AttackType represents the type of chaos attack
+type AttackType string
+
+const (
+	AttackTypeKill    AttackType = "kill"
+	AttackTypeSuspend AttackType = "suspend"
+	AttackTypeDelay   AttackType = "delay"
+)
+
+// Event represents a chaos or recovery event
+type Event struct {
+	Type      EventType `json:"type"`
+	Timestamp time.Time `json:"timestamp"`
+	NodeID    string    `json:"node_id"`
+	Data      EventData `json:"data,omitempty"`
+}
+
+// EventData contains event-specific data
+type EventData struct {
+	AttackType    AttackType `json:"attack_type,omitempty"`
+	DelayDuration string     `json:"delay_duration,omitempty"`
+	Attempt       int        `json:"attempt,omitempty"`
+	Error         string     `json:"error,omitempty"`
+}
+
+// NewChaosAttackEvent creates a new chaos attack event
+func NewChaosAttackEvent(nodeID string, attackType AttackType) Event {
+	return Event{
+		Type:      EventChaosAttack,
+		Timestamp: time.Now(),
+		NodeID:    nodeID,
+		Data: EventData{
+			AttackType: attackType,
+		},
+	}
+}
+
+// NewChaosAttackEventWithDelay creates a chaos attack event for delay injection
+func NewChaosAttackEventWithDelay(nodeID string, delay time.Duration) Event {
+	return Event{
+		Type:      EventChaosAttack,
+		Timestamp: time.Now(),
+		NodeID:    nodeID,
+		Data: EventData{
+			AttackType:    AttackTypeDelay,
+			DelayDuration: delay.String(),
+		},
+	}
+}
+
+// NewChaosResumeEvent creates a chaos resume event
+func NewChaosResumeEvent(nodeID string) Event {
+	return Event{
+		Type:      EventChaosResume,
+		Timestamp: time.Now(),
+		NodeID:    nodeID,
+	}
+}
+
+// NewRecoveryStartEvent creates a recovery start event
+func NewRecoveryStartEvent(nodeID string, attempt int) Event {
+	return Event{
+		Type:      EventRecoveryStart,
+		Timestamp: time.Now(),
+		NodeID:    nodeID,
+		Data: EventData{
+			Attempt: attempt,
+		},
+	}
+}
+
+// NewRecoverySuccessEvent creates a recovery success event
+func NewRecoverySuccessEvent(nodeID string) Event {
+	return Event{
+		Type:      EventRecoverySuccess,
+		Timestamp: time.Now(),
+		NodeID:    nodeID,
+	}
+}
+
+// NewRecoveryFailedEvent creates a recovery failed event
+func NewRecoveryFailedEvent(nodeID string, err error) Event {
+	errMsg := ""
+	if err != nil {
+		errMsg = err.Error()
+	}
+	return Event{
+		Type:      EventRecoveryFailed,
+		Timestamp: time.Now(),
+		NodeID:    nodeID,
+		Data: EventData{
+			Error: errMsg,
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- カオスエンジニアリングの活動（攻撃・復旧）をリアルタイムで可視化
- イベント駆動アーキテクチャの導入
- フロントエンドにタイムライン・統計・アニメーションを追加

## 変更内容

### イベントシステム（新規）
- `internal/events/events.go` - イベント型定義
- `internal/events/bus.go` - Pub/Sub イベントバス
- `internal/events/bus_test.go` - テスト

### バックエンド修正
- `internal/chaos/chaos.go` - 攻撃時にイベント発行、統計追跡
- `internal/recovery/recovery.go` - 復旧時にイベント発行
- `internal/scenario/scenario.go` - EventBus 接続
- `internal/api/server.go` - WebSocket イベント配信、メトリクス API 実装

### フロントエンド
- `internal/api/static/index.html` - 可視化 UI 全面刷新
  - カオスタイムライン（イベント履歴）
  - 攻撃統計カード
  - 攻撃タイプ分布バー
  - ノードアニメーション（kill: 💀赤、suspend: ⏸️黄、delay: 🕐青、recovery: ✅緑）

## Test plan

- [x] `make quality` パス（テスト・リント）
- [ ] `make server` でサーバー起動
- [ ] ブラウザで http://localhost:8080 アクセス
- [ ] resilience シナリオ実行
- [ ] タイムラインにイベントがリアルタイム表示されることを確認
- [ ] ノード攻撃時にアニメーションが表示されることを確認
- [ ] 統計カードが更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)